### PR TITLE
Bug-fix: Leave AppSessionContext state on timeout

### DIFF
--- a/lib/pcf-service-consumer/npcf-process.c
+++ b/lib/pcf-service-consumer/npcf-process.c
@@ -291,8 +291,13 @@ bool _pcf_process_event(ogs_event_t *e)
                 ogs_debug("App shutting down client request aborted - destroying app session");
                 if (sess) pcf_app_sess_remove(sess);
                 break;
+            case OGS_TIMEUP:
+                /* Client request took too long - leave state */
+                ogs_warn("Timeout connecting to the client - app session unchanged");
+                break;
             default:
                 /* Some other error happened - client request failed */
+                ogs_debug("OGS_EVENT_SBI_CLIENT: SBI client response state = %i", e->sbi.state);
                 if (response) {
                     ogs_error("Problem with %s %s request", response->h.method, response->h.uri);
                 } else {

--- a/lib/pcf-service-consumer/pcf-service-consumer.h
+++ b/lib/pcf-service-consumer/pcf-service-consumer.h
@@ -170,9 +170,9 @@ PCF_SVC_CONSUMER_API bool pcf_session_create_app_session(pcf_session_t *session,
  * Update the MediaComponents for an AppSessionContext
  *
  * @param sess The AppSessionContext to update the MediaComponents for.
- * @param media_component The map of MediaComponent entries for the update.
+ * @param media_component The map of MediaComponentRm entries for the update.
  */
-PCF_SVC_CONSUMER_API bool pcf_session_update_app_session(pcf_app_session_t *sess, OpenAPI_list_t *media_component);
+PCF_SVC_CONSUMER_API bool pcf_session_update_app_session(pcf_app_session_t *sess, OpenAPI_list_t *media_component_rm_map);
 
 /**
  * Release an AppSessionContext


### PR DESCRIPTION
Do not free the app session context if the client request error is a timeout.

Fix update function documentation to indicate the correct structure type to use.