### PR TITLE
Add callback after MBS Session DELETE operation

### DIFF
--- a/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
+++ b/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
@@ -176,9 +176,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
             /* response to MB-SMF MBS SESSION API request or discovery */
             if (ogs_sbi_parse_header(&message, &response->h) != OGS_OK) {
                 ogs_error("Failed to parse header from client response for MB-SMF MBS Session transaction");
-                if (sess->create_result_cb) {
-                    sess->create_result_cb(_priv_mbs_session_to_public(sess), OGS_ERROR, NULL, sess->create_result_cb_data);
-                }
+                _mbs_session_do_create_error_callback(sess, message.ProblemDetails);
                 ogs_sbi_message_free(&message);
                 break;
             }
@@ -200,28 +198,16 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                             if (response->status >= 200 && response->status < 300) {
                                 ogs_debug("Client response for Create MBS Session received");
                                 if (_nmbsmf_mbs_session_parse(&message, sess) == OGS_OK) {
-                                    if (sess->create_result_cb) {
-                                        ogs_debug("Forwarding creation result to calling application");
-                                        sess->create_result_cb(_priv_mbs_session_to_public(sess), OGS_OK, NULL,
-                                                               sess->create_result_cb_data);
-                                    }
+                                    _mbs_session_do_created_callback(sess);
                                     /* push pending changes (further subscriptions, etc) */
                                     _mbs_session_push_changes(sess);
                                 } else {
                                     ogs_warn("Errors in response from MB-SMF");
-                                    if (sess->create_result_cb) {
-                                        ogs_debug("Forwarding creation failure to calling application");
-                                        sess->create_result_cb(_priv_mbs_session_to_public(sess), OGS_ERROR, NULL,
-                                                               sess->create_result_cb_data);
-                                    }
+                                    _mbs_session_do_create_error_callback(sess, NULL);
                                 }
                             } else {
                                 ogs_error("MB-SMF responded with a %i status code", response->status);
-                                if (sess->create_result_cb) {
-                                    ogs_debug("Forwarding creation error to calling application");
-                                    sess->create_result_cb(_priv_mbs_session_to_public(sess), OGS_ERROR,
-                                                           message.ProblemDetails, sess->create_result_cb_data);
-                                }
+                                _mbs_session_do_create_error_callback(sess, message.ProblemDetails);
                             }
                             break;
                         DEFAULT
@@ -246,7 +232,25 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                         END
                         break;
                     DEFAULT
-                        /* .../mbs-sessions/... */
+                        /* .../mbs-sessions/{mbs-session-id}/... */
+                        const char *mbs_session_id = xact->request->h.resource.component[1];
+
+                        SWITCH(xact->request->h.resource.component[2])
+                        CASE("OGS_SWITCH_NULL")
+                            /* .../mbs-sessions/{mbs-session-id} */
+                            SWITCH(xact->request->h.method)
+                            CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                                _nmbsmf_mbs_session_delete_response(sess, &message, response);
+                                break;
+                            DEFAULT
+                                break;
+                            END
+                            break;
+                        DEFAULT
+                            /* .../mbs-sessions/{mbs-session-id}/... */
+                            ogs_warn("Response for unknown path: .../mbs-sessions/%s/%s...", mbs_session_id, xact->request->h.resource.component[2]);
+                            break;
+                        END
                         break;
                     END
                     break;
@@ -329,11 +333,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                         CASE(OGS_SBI_HTTP_METHOD_POST)
                             /* Create MBS Session */
                             ogs_warn("Create MBS Session request timed out");
-                            if (sess->create_result_cb) {
-                                ogs_debug("Calling application callback for MBS Session creation with ETIMEDOUT");
-                                sess->create_result_cb(_priv_mbs_session_to_public(sess), OGS_ETIMEDOUT, NULL,
-                                                       sess->create_result_cb_data);
-                            }
+                            _mbs_session_do_create_timeout_callback(sess);
                             break;
                         DEFAULT
                             break;

--- a/lib/mb-smf-service-consumer/mbs-session.c
+++ b/lib/mb-smf-service-consumer/mbs-session.c
@@ -647,10 +647,8 @@ bool _mbs_session_push_changes(_priv_mbs_session_t *sess)
     ogs_debug("Pushing changes for MbsSession [%p (%p)]", sess, _priv_mbs_session_to_public(sess));
 
     if (sess->deleted) {
-        ogs_debug("Session has been deleted, removing...");
+        ogs_debug("Session has been deleted, sending removal request...");
         _mbs_session_send_remove(sess);
-        _context_remove_mbs_session(sess); // TODO: This drops the MBS session object before the removal request has been responded
-        _mbs_session_delete(sess);         //       to. Move these two lines to client response for MBS Session removal?
         return true;
     }
 
@@ -758,6 +756,34 @@ void _mbs_session_send_remove(_priv_mbs_session_t *session)
                                             _nmbsmf_mbs_session_build_remove, session, NULL);
 
     ogs_sbi_discover_and_send(xact);
+}
+
+void _mbs_session_do_callback(_priv_mbs_session_t *sess, int result, const OpenAPI_problem_details_t *problem_details)
+{
+    if (!sess) return;
+    if (!sess->create_result_cb) return;
+
+    sess->create_result_cb(_priv_mbs_session_to_public(sess), result, problem_details, sess->create_result_cb_data);
+}
+
+void _mbs_session_do_created_callback(_priv_mbs_session_t *session)
+{
+    _mbs_session_do_callback(session, OGS_OK, NULL);
+}
+
+void _mbs_session_do_deleted_callback(_priv_mbs_session_t *session)
+{
+    _mbs_session_do_callback(session, OGS_DONE, NULL);
+}
+
+void _mbs_session_do_create_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details)
+{
+    _mbs_session_do_callback(session, OGS_ERROR, problem_details);
+}
+
+void _mbs_session_do_create_timeout_callback(_priv_mbs_session_t *session)
+{
+    _mbs_session_do_callback(session, OGS_ETIMEDOUT, NULL);
 }
 
 void _mbs_session_subscriptions_update(_priv_mbs_session_t *sess)

--- a/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.c
+++ b/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.c
@@ -161,6 +161,17 @@ int _nmbsmf_mbs_session_parse(ogs_sbi_message_t *message, _priv_mbs_session_t *s
     return OGS_OK;
 }
 
+void _nmbsmf_mbs_session_delete_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response)
+{
+    if (!sess || !message || !response) return;
+
+    /* Tell application that the MBS Session was deleted */
+    _mbs_session_do_deleted_callback(sess);
+
+    /* Remove session from context */
+    _context_remove_mbs_session(sess);
+}
+
 int _nmbsmf_mbs_session_subscription_report_list_handler(_priv_mbs_status_subscription_t *subsc,
                                                          OpenAPI_list_t *event_report_list)
 {

--- a/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.h
+++ b/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.h
@@ -19,10 +19,10 @@ extern "C" {
 typedef struct _priv_mbs_session_s _priv_mbs_session_t;
 
 int _nmbsmf_mbs_session_parse(ogs_sbi_message_t *message, _priv_mbs_session_t *sess);
+void _nmbsmf_mbs_session_delete_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response);
 
 int _nmbsmf_mbs_session_subscription_report_list_handler(_priv_mbs_status_subscription_t *subsc, OpenAPI_list_t *event_report_list);
 void _nmbsmf_mbs_session_subscription_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response);
-
 
 #ifdef __cplusplus
 }

--- a/lib/mb-smf-service-consumer/priv_mbs-session.h
+++ b/lib/mb-smf-service-consumer/priv_mbs-session.h
@@ -87,6 +87,12 @@ void _mbs_session_send_create(_priv_mbs_session_t *session);
 void _mbs_session_send_update(_priv_mbs_session_t *session);
 void _mbs_session_send_remove(_priv_mbs_session_t *session);
 
+void _mbs_session_do_callback(_priv_mbs_session_t *session, int result, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_created_callback(_priv_mbs_session_t *session);
+void _mbs_session_do_deleted_callback(_priv_mbs_session_t *session);
+void _mbs_session_do_create_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_create_timeout_callback(_priv_mbs_session_t *session);
+
 void _mbs_session_subscriptions_update(_priv_mbs_session_t *sess);
 _priv_mbs_status_subscription_t *_mbs_session_find_active_subscription(const _priv_mbs_session_t *session, const char *id);
 _priv_mbs_status_subscription_t *_mbs_session_find_subscription(const _priv_mbs_session_t *session, const char *correlation_id);

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 project('rt-5gc-service-consumers', 'c',
-    version : '2.1.0',
+    version : '2.1.1',
     license : '5G-MAG Public',
     meson_version : '>= 1.4.0',
     default_options : [


### PR DESCRIPTION
During investigation of the MBSF race condition reported on 5G-MAG/rt-mbs-function#16, it was observed that the MB-SMF service consumer library was not invoking a callback to the invoking application after successfully destroying an MBS Session in the MB-SMF. This PR fixes that and goes along with PR 5G-MAG/rt-mbs-function#17.