### PR TITLE
Fix for memory leak and prevent segfault

### DIFF
--- a/lib/mb-smf-service-consumer/context.c
+++ b/lib/mb-smf-service-consumer/context.c
@@ -245,7 +245,9 @@ bool _context_is_notification_server(ogs_sbi_server_t *server)
         ogs_list_for_each(&sess->new_subscriptions, subsc) {
             if (subsc->cache && subsc->cache->notif_server == server) return true;
         }
-        if (!ogs_hash_do(__check_notification_server, server, sess->active_subscriptions)) return true;
+        if (sess->active_subscriptions && !ogs_hash_do(__check_notification_server, server, sess->active_subscriptions)) {
+            return true;
+        }
     }
     return false;
 }

--- a/lib/mb-smf-service-consumer/nmbsmf-mbs-session-build.c
+++ b/lib/mb-smf-service-consumer/nmbsmf-mbs-session-build.c
@@ -157,10 +157,19 @@ ogs_sbi_request_t *_nmbsmf_mbs_session_build_update(void *context, void *data)
             OpenAPI_list_add(msg.PatchItemList, patch->item);
             ogs_free(patch);
         }
+        ogs_free(patches);
     }
 
     ogs_sbi_request_t *req = ogs_sbi_build_request(&msg);
     ogs_expect(req);
+
+    if (msg.PatchItemList) {
+        OpenAPI_lnode_t *node = NULL;
+        OpenAPI_list_for_each(msg.PatchItemList, node) {
+            OpenAPI_patch_item_free(node->data);
+        }
+        OpenAPI_list_free(msg.PatchItemList);
+    }
 
     return req;
 }


### PR DESCRIPTION
Here are a couple of bug fixes found during MBSF testing.

The first fixes a memory leak when an MBS Session update is sent to the MB-SMF and the second prevents a segmentation fault while attempting to process notifications.