### PR TITLE
Bug-fixes for various bugs and memory leaks in the MB-SMF service consumer library

### DIFF
--- a/lib/mb-smf-service-consumer/civic-address.c
+++ b/lib/mb-smf-service-consumer/civic-address.c
@@ -76,7 +76,7 @@ void _civic_addresses_copy(ogs_list_t **dst, const ogs_list_t *src)
         }
         return;
     }
-    
+
     if (!*dst) {
         *dst = (typeof(*dst))ogs_calloc(1, sizeof(**dst));
     }
@@ -154,7 +154,7 @@ ogs_list_t *_civic_addresses_patch_list(const ogs_list_t *a, const ogs_list_t *b
                     if (!patches) patches = (typeof(patches))ogs_calloc(1, sizeof(*patches));
                     ogs_list_add(patches, patch);
                 }
-                idx++;   
+                idx++;
                 if (a_addr) a_addr = (mb_smf_sc_civic_address_t*)ogs_list_next(a_addr);
                 if (b_addr) b_addr = (mb_smf_sc_civic_address_t*)ogs_list_next(b_addr);
             }

--- a/lib/mb-smf-service-consumer/json-patch.c
+++ b/lib/mb-smf-service-consumer/json-patch.c
@@ -56,6 +56,7 @@ _json_patch_t *_json_patch_new(OpenAPI_patch_operation_e op, const char *path, c
     _json_patch_t *dst = (_json_patch_t*)ogs_calloc(1, sizeof(*dst));
     dst->item = OpenAPI_patch_item_create(op, ogs_strdup(path), NULL,
                                           (value && cJSON_IsNull(value)), value?OpenAPI_any_type_create(value):NULL);
+    if (value) cJSON_Delete(value);
     return dst;
 }
 

--- a/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
+++ b/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
@@ -176,7 +176,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
             /* response to MB-SMF MBS SESSION API request or discovery */
             if (ogs_sbi_parse_header(&message, &response->h) != OGS_OK) {
                 ogs_error("Failed to parse header from client response for MB-SMF MBS Session transaction");
-                _mbs_session_do_create_error_callback(sess, message.ProblemDetails);
+                _mbs_session_do_create_error_callback(sess, message.ProblemDetails); // don't know if this is a create or update
                 ogs_sbi_message_free(&message);
                 break;
             }
@@ -241,6 +241,9 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                             SWITCH(xact->request->h.method)
                             CASE(OGS_SBI_HTTP_METHOD_DELETE)
                                 _nmbsmf_mbs_session_delete_response(sess, &message, response);
+                                break;
+                            CASE(OGS_SBI_HTTP_METHOD_PATCH)
+                                _nmbsmf_mbs_session_patch_response(sess, &message, response);
                                 break;
                             DEFAULT
                                 break;

--- a/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
+++ b/lib/mb-smf-service-consumer/mb-smf-service-consumer.c
@@ -49,6 +49,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
 {
     ogs_sbi_xact_t *xact = NULL;
     ogs_sbi_response_t *response = NULL;
+    _ref_count_sbi_object_t *sbi_object = NULL;
 
     if (!e) return false;
 
@@ -162,6 +163,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                     _nmbsmf_tmgi_allocated(xact, &message);
                     break;
                 CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                    sbi_object = _ref_count_sbi_object_ref(tmgi->sbi_object);
                     _nmbsmf_tmgi_deallocated(xact, &message);
                     break;
                 DEFAULT
@@ -240,6 +242,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
                             /* .../mbs-sessions/{mbs-session-id} */
                             SWITCH(xact->request->h.method)
                             CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                                sbi_object = _ref_count_sbi_object_ref(sess->sbi_object);
                                 _nmbsmf_mbs_session_delete_response(sess, &message, response);
                                 break;
                             CASE(OGS_SBI_HTTP_METHOD_PATCH)
@@ -366,6 +369,7 @@ MB_SMF_CLIENT_API bool mb_smf_sc_process_event(ogs_event_t *e)
     }
 
     if (xact) ogs_sbi_xact_remove(xact);
+    if (sbi_object) _ref_count_sbi_object_unref(sbi_object);
 
     return true;
 }

--- a/lib/mb-smf-service-consumer/mbs-fsa-id.c
+++ b/lib/mb-smf-service-consumer/mbs-fsa-id.c
@@ -34,7 +34,7 @@ MB_SMF_CLIENT_API void mb_smf_sc_mbs_fsa_id_delete(mb_smf_sc_mbs_fsa_id_t *fsa_i
 void _mbs_fsa_ids_copy(ogs_list_t *dst, const ogs_list_t *src)
 {
     _mbs_fsa_ids_clear(dst);
-    mb_smf_sc_mbs_fsa_id_t *fsa_id; 
+    mb_smf_sc_mbs_fsa_id_t *fsa_id;
     ogs_list_for_each(src, fsa_id) {
         mb_smf_sc_mbs_fsa_id_t *new_fsa_id = NULL;
         _mbs_fsa_id_copy(&new_fsa_id, fsa_id);

--- a/lib/mb-smf-service-consumer/mbs-session.c
+++ b/lib/mb-smf-service-consumer/mbs-session.c
@@ -200,9 +200,44 @@ MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_push_all_changes()
     return ret;
 }
 
-MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_create_result_cb callback, void *data)
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
 {
     return _mbs_session_set_callback(_priv_mbs_session_from_public(session), callback, data);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_create_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_create_callback(_priv_mbs_session_from_public(session), callback, data);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_update_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_update_callback(_priv_mbs_session_from_public(session), callback, data);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_delete_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_delete_callback(_priv_mbs_session_from_public(session), callback, data);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn)
+{
+    return _mbs_session_set_callback_freefn(_priv_mbs_session_from_public(session), callback, data, data_free_fn);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_create_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn)
+{
+    return _mbs_session_set_create_callback_freefn(_priv_mbs_session_from_public(session), callback, data, data_free_fn);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_update_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn)
+{
+    return _mbs_session_set_update_callback_freefn(_priv_mbs_session_from_public(session), callback, data, data_free_fn);
+}
+
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_delete_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn)
+{
+    return _mbs_session_set_delete_callback_freefn(_priv_mbs_session_from_public(session), callback, data, data_free_fn);
 }
 
 MB_SMF_CLIENT_API const char *mb_smf_sc_mbs_session_get_resource_id(const mb_smf_sc_mbs_session_t *session)
@@ -243,9 +278,10 @@ void _mbs_session_delete(_priv_mbs_session_t *session)
     if (!session) return;
 
     // mb_smf_sc_mbs_session_t session->session
-    _mbs_session_public_clear(&session->session);
     _mbs_session_public_free(session->previous_session);
     session->previous_session = NULL;
+
+    _mbs_session_release_callback_data(session);
 
     _priv_mbs_status_subscription_t *next, *node;
 
@@ -275,6 +311,8 @@ void _mbs_session_delete(_priv_mbs_session_t *session)
         session->sbi_object = NULL;
     }
 
+    _mbs_session_public_clear(&session->session);
+
     // session
     ogs_free(session);
 }
@@ -295,7 +333,9 @@ void _mbs_session_public_clear(mb_smf_sc_mbs_session_t *session)
         session->ssm = NULL;
     }
 
-    /* session->tmgi: TMGI held elsewhere in context, don't free here */
+    if (session->tmgi_req && session->tmgi != NULL) {
+        _tmgi_free(_priv_tmgi_from_public(session->tmgi));
+    }
     session->tmgi = NULL;
     session->tmgi_req = true;
 
@@ -377,8 +417,16 @@ void _mbs_session_public_copy(mb_smf_sc_mbs_session_t **dest, const mb_smf_sc_mb
         }
     }
 
-    /* copy TMGI (we don't own, so copying pointer is fine) */
-    dst->tmgi = src->tmgi;
+    /* copy TMGI (we don't own if we didn't request it, so copying pointer is fine) */
+    if (src->tmgi_req) {
+        /* source owns the TMGI, so copy it too */
+        _priv_tmgi_t *dest_tmgi = _priv_tmgi_from_public(dst->tmgi);
+        _tmgi_copy(&dest_tmgi, _priv_tmgi_from_public_const(src->tmgi));
+        dst->tmgi = _priv_tmgi_to_public(dest_tmgi);
+    } else {
+        /* source doesn't own TMGI because it wasn't requested, so copying pointer is fine */
+        dst->tmgi = src->tmgi;
+    }
 
     /* copy UDP tunnel */
     if (dst->mb_upf_udp_tunnel) ogs_freeaddrinfo(dst->mb_upf_udp_tunnel);
@@ -632,11 +680,64 @@ bool _mbs_session_set_tmgi(_priv_mbs_session_t *session, _priv_tmgi_t *tmgi)
     return true;
 }
 
-bool _mbs_session_set_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_create_result_cb callback, void *data)
+bool _mbs_session_set_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_callback_freefn(session, callback, data, NULL);
+}
+
+bool _mbs_session_set_create_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_create_callback_freefn(session, callback, data, NULL);
+}
+
+bool _mbs_session_set_update_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_update_callback_freefn(session, callback, data, NULL);
+}
+
+bool _mbs_session_set_delete_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data)
+{
+    return _mbs_session_set_delete_callback_freefn(session, callback, data, NULL);
+}
+
+bool _mbs_session_set_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data,
+                                       mb_smf_sc_mbs_session_cb_data_free_fn data_free)
 {
     if (!session || session->deleted) return false;
+    bool result = true;
+    result &= _mbs_session_set_create_callback_freefn(session, callback, data, data_free);
+    result &= _mbs_session_set_update_callback_freefn(session, callback, data, data_free);
+    result &= _mbs_session_set_delete_callback_freefn(session, callback, data, data_free);
+    return result;
+}
+
+bool _mbs_session_set_create_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data,
+                                             mb_smf_sc_mbs_session_cb_data_free_fn data_free)
+{
+    if (session->create_result_cb_data != data) _mbs_session_release_create_callback_data(session);
     session->create_result_cb = callback;
     session->create_result_cb_data = data;
+    session->create_cb_data_free = data_free;
+    return true;
+}
+
+bool _mbs_session_set_update_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data,
+                                             mb_smf_sc_mbs_session_cb_data_free_fn data_free)
+{
+    if (session->update_result_cb_data != data) _mbs_session_release_update_callback_data(session);
+    session->update_result_cb = callback;
+    session->update_result_cb_data = data;
+    session->update_cb_data_free = data_free;
+    return true;
+}
+
+bool _mbs_session_set_delete_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data,
+                                             mb_smf_sc_mbs_session_cb_data_free_fn data_free)
+{
+    if (session->delete_result_cb_data != data) _mbs_session_release_delete_callback_data(session);
+    session->delete_result_cb = callback;
+    session->delete_result_cb_data = data;
+    session->delete_cb_data_free = data_free;
     return true;
 }
 
@@ -758,7 +859,47 @@ void _mbs_session_send_remove(_priv_mbs_session_t *session)
     ogs_sbi_discover_and_send(xact);
 }
 
-void _mbs_session_do_callback(_priv_mbs_session_t *sess, int result, const OpenAPI_problem_details_t *problem_details)
+void _mbs_session_release_callback_data(_priv_mbs_session_t *sess)
+{
+    _mbs_session_release_create_callback_data(sess);
+    _mbs_session_release_update_callback_data(sess);
+    _mbs_session_release_delete_callback_data(sess);
+}
+
+void _mbs_session_release_create_callback_data(_priv_mbs_session_t *sess)
+{
+    if (!sess) return;
+    if (!sess->create_result_cb_data) return;
+    if (sess->create_cb_data_free && sess->create_result_cb_data != sess->delete_result_cb_data &&
+         sess->create_result_cb_data != sess->update_result_cb_data) {
+        sess->create_cb_data_free(sess->create_result_cb_data);
+    }
+    sess->create_result_cb_data = NULL;
+}
+
+void _mbs_session_release_update_callback_data(_priv_mbs_session_t *sess)
+{
+    if (!sess) return;
+    if (!sess->update_result_cb_data) return;
+    if (sess->update_cb_data_free && sess->update_result_cb_data != sess->create_result_cb_data &&
+         sess->update_result_cb_data != sess->delete_result_cb_data) {
+        sess->update_cb_data_free(sess->update_result_cb_data);
+    }
+    sess->update_result_cb_data = NULL;
+}
+
+void _mbs_session_release_delete_callback_data(_priv_mbs_session_t *sess)
+{
+    if (!sess) return;
+    if (!sess->delete_result_cb_data) return;
+    if (sess->delete_cb_data_free && sess->delete_result_cb_data != sess->create_result_cb_data &&
+         sess->delete_result_cb_data != sess->update_result_cb_data) {
+        sess->delete_cb_data_free(sess->delete_result_cb_data);
+    }
+    sess->delete_result_cb_data = NULL;
+}
+
+void _mbs_session_do_create_callback(_priv_mbs_session_t *sess, int result, const OpenAPI_problem_details_t *problem_details)
 {
     if (!sess) return;
     if (!sess->create_result_cb) return;
@@ -766,24 +907,55 @@ void _mbs_session_do_callback(_priv_mbs_session_t *sess, int result, const OpenA
     sess->create_result_cb(_priv_mbs_session_to_public(sess), result, problem_details, sess->create_result_cb_data);
 }
 
+void _mbs_session_do_update_callback(_priv_mbs_session_t *sess, int result, const OpenAPI_problem_details_t *problem_details)
+{
+    if (!sess) return;
+    if (!sess->update_result_cb) return;
+
+    sess->update_result_cb(_priv_mbs_session_to_public(sess), result, problem_details, sess->update_result_cb_data);
+}
+
+void _mbs_session_do_delete_callback(_priv_mbs_session_t *sess, int result, const OpenAPI_problem_details_t *problem_details)
+{
+    if (!sess) return;
+    if (!sess->delete_result_cb) return;
+
+    sess->delete_result_cb(_priv_mbs_session_to_public(sess), result, problem_details, sess->delete_result_cb_data);
+}
+
 void _mbs_session_do_created_callback(_priv_mbs_session_t *session)
 {
-    _mbs_session_do_callback(session, OGS_OK, NULL);
+    _mbs_session_do_create_callback(session, OGS_OK, NULL);
 }
 
 void _mbs_session_do_deleted_callback(_priv_mbs_session_t *session)
 {
-    _mbs_session_do_callback(session, OGS_DONE, NULL);
+    _mbs_session_do_delete_callback(session, OGS_DONE, NULL);
+}
+
+void _mbs_session_do_updated_callback(_priv_mbs_session_t *session)
+{
+    _mbs_session_do_update_callback(session, OGS_OK, NULL);
 }
 
 void _mbs_session_do_create_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details)
 {
-    _mbs_session_do_callback(session, OGS_ERROR, problem_details);
+    _mbs_session_do_create_callback(session, OGS_ERROR, problem_details);
 }
 
 void _mbs_session_do_create_timeout_callback(_priv_mbs_session_t *session)
 {
-    _mbs_session_do_callback(session, OGS_ETIMEDOUT, NULL);
+    _mbs_session_do_create_callback(session, OGS_ETIMEDOUT, NULL);
+}
+
+void _mbs_session_do_update_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details)
+{
+    _mbs_session_do_update_callback(session, OGS_ERROR, problem_details);
+}
+
+void _mbs_session_do_update_timeout_callback(_priv_mbs_session_t *session)
+{
+    _mbs_session_do_update_callback(session, OGS_ETIMEDOUT, NULL);
 }
 
 void _mbs_session_subscriptions_update(_priv_mbs_session_t *sess)

--- a/lib/mb-smf-service-consumer/mbs-session.h
+++ b/lib/mb-smf-service-consumer/mbs-session.h
@@ -56,13 +56,18 @@ typedef enum {
     MBS_SESSION_ACTIVITY_STATUS_INACTIVE
 } mb_smf_sc_activity_status_e;
 
-/** MBS Session creation/destruction callback
+/** MBS Session creation/update/destruction callback
  *
- * This callback is used when an MBS Session create has either succeeded or failed or when the MBS Session is destroyed.
+ * This callback is used when an MBS Session create or update operation has either succeeded or failed or when the MBS Session is
+ * destroyed.
  *
- * On creation, @p result will be `OGS_OK` when the creation succeeded, `OGS_ERROR` for an error during creation or `OGS_TIMEOUT`
+ * On creation, @p result will be `OGS_OK` when the creation succeeded, `OGS_ERROR` for an error during creation or `OGS_ETIMEOUT`
  * if the creation operation timed out. If the @p result is `OGS_ERROR` then a ProblemDetails associated with the error is passed
  * in the @p problem_details parameter.
+ *
+ * On update, @p result will be `OGS_OK` when the update succeeded, `OGS_ERROR` for an error during update or `OGS_ETIMEOUT` if the
+ * update operation timed out. If the @p result is `OGS_ERROR` then a ProblemDetails associated with the error is passed in the
+ * @p problem_details parameter.
  *
  * On destruction, @p result will be `OGS_DONE`.
  *
@@ -74,8 +79,28 @@ typedef enum {
  *
  * @see mb_smf_sc_mbs_session_set_callback()
  */
-typedef void (*mb_smf_sc_mbs_session_create_result_cb)(mb_smf_sc_mbs_session_t *session, int result,
-                                                       const OpenAPI_problem_details_t *problem_details, void *data);
+typedef void (*mb_smf_sc_mbs_session_result_cb)(mb_smf_sc_mbs_session_t *session, int result,
+                                                const OpenAPI_problem_details_t *problem_details, void *data);
+
+/**@{
+ */
+/** MBS Session creation/update/destruction callback type aliases
+ *
+ * These alias the callback function type for the create, update and delete operations.
+ * The `mb_smf_sc_mbs_session_create_result_cb` type is kept for backward compatibility.
+ */
+typedef mb_smf_sc_mbs_session_result_cb mb_smf_sc_mbs_session_create_result_cb;
+typedef mb_smf_sc_mbs_session_result_cb mb_smf_sc_mbs_session_update_result_cb;
+typedef mb_smf_sc_mbs_session_result_cb mb_smf_sc_mbs_session_delete_result_cb;
+/**@}
+ */
+
+/** MBS Session callback data free function type
+ *
+ * If provided, a function of this prototype is called to free the @a data provided when setting the callback function.
+ * This function is only called if @a data was not `NULL` and the same @a data pointer has been freed for all callback operations.
+ */
+typedef void (*mb_smf_sc_mbs_session_cb_data_free_fn)(void *data);
 
 /** MBS Session
  *
@@ -240,11 +265,12 @@ MB_SMF_CLIENT_API mb_smf_sc_mbs_status_subscription_t *mb_smf_sc_mbs_session_fin
  */
 MB_SMF_CLIENT_API mb_smf_sc_mbs_status_subscription_t *mb_smf_sc_mbs_session_find_subscription_by_correlation(const mb_smf_sc_mbs_session_t *session, const char *correlation_id);
 
-/** Set the callback for the MBS Session
+/** Set all callbacks for the MBS Session
  * @memberof mb_smf_sc_mbs_session_s
  * @public
  *
- * The callback will be called when the MBS Session when the result of a create attempt on the MB-SMF is received.
+ * The callback will be called for the MBS Session when the result of a create or update attempt on the MB-SMF is received, or when
+ * the MBS Session is deleted.
  *
  * @param session The MBS Session to set the callback for.
  * @param callback The callback to set.
@@ -252,7 +278,110 @@ MB_SMF_CLIENT_API mb_smf_sc_mbs_status_subscription_t *mb_smf_sc_mbs_session_fin
  *
  * @return `true` if the callback is updated successfully.
  */
-MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_create_result_cb callback, void *data);
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+
+/** Set the create callback for the MBS Session
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the result of a create attempt on the MB-SMF is received.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_create_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+
+/** Set the update callback for the MBS Session
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the result of an update attempt on the MB-SMF is received.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_update_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+
+/** Set the delete callback for the MBS Session
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the session is deleted.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_delete_callback(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+
+/** Set all callbacks for the MBS Session (with data free function)
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the result of a create or update attempt on the MB-SMF is received, or when
+ * the MBS Session is deleted.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ * @param data_free_function The function to call to free @a data when it is no longer needed.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_function);
+
+/** Set the create callback for the MBS Session (with data free function)
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the result of a create attempt on the MB-SMF is received.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ * @param data_free_function The function to call to free @a data when it is no longer needed.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_create_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_function);
+
+/** Set the update callback for the MBS Session (with data free function)
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the result of an update attempt on the MB-SMF is received.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ * @param data_free_function The function to call to free @a data when it is no longer needed.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_update_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_function);
+
+/** Set the delete callback for the MBS Session (with data free function)
+ * @memberof mb_smf_sc_mbs_session_s
+ * @public
+ *
+ * The callback will be called for the MBS Session when the session is deleted.
+ *
+ * @param session The MBS Session to set the callback for.
+ * @param callback The callback to set.
+ * @param data The @a data parameter to call the callback with.
+ * @param data_free_function The function to call to free @a data when it is no longer needed.
+ *
+ * @return `true` if the callback is updated successfully.
+ */
+MB_SMF_CLIENT_API bool mb_smf_sc_mbs_session_set_delete_callback_with_freefn(mb_smf_sc_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_function);
 
 /** Get the resource ID for the MBS Session at the MB-SMF
  * @memberof mb_smf_sc_mbs_session_s

--- a/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.c
+++ b/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.c
@@ -172,6 +172,27 @@ void _nmbsmf_mbs_session_delete_response(_priv_mbs_session_t *sess, ogs_sbi_mess
     _context_remove_mbs_session(sess);
 }
 
+void _nmbsmf_mbs_session_patch_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response)
+{
+    if (!sess || !message || !response) return;
+
+    if (message->res_status >= 200 && message->res_status <= 299) {
+        /* patch success, update copy */
+        _mbs_session_public_copy(&sess->previous_session, &sess->session);
+    } else if (message->res_status <= 199 || (message->res_status >= 300 && message->res_status <= 399)) {
+        /* no change */
+    } else if (message->res_status >= 400) {
+        /* error, revert changes */
+        if (sess->previous_session) {
+            mb_smf_sc_mbs_session_t *dst = &sess->session;
+            _mbs_session_public_copy(&dst, sess->previous_session);
+        }
+    }
+
+    /* callback to notify application of a change to MBS Session */
+    _mbs_session_do_updated_callback(sess);
+}
+
 int _nmbsmf_mbs_session_subscription_report_list_handler(_priv_mbs_status_subscription_t *subsc,
                                                          OpenAPI_list_t *event_report_list)
 {

--- a/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.h
+++ b/lib/mb-smf-service-consumer/nmbsmf-mbs-session-handle.h
@@ -20,6 +20,7 @@ typedef struct _priv_mbs_session_s _priv_mbs_session_t;
 
 int _nmbsmf_mbs_session_parse(ogs_sbi_message_t *message, _priv_mbs_session_t *sess);
 void _nmbsmf_mbs_session_delete_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response);
+void _nmbsmf_mbs_session_patch_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response);
 
 int _nmbsmf_mbs_session_subscription_report_list_handler(_priv_mbs_status_subscription_t *subsc, OpenAPI_list_t *event_report_list);
 void _nmbsmf_mbs_session_subscription_response(_priv_mbs_session_t *sess, ogs_sbi_message_t *message, ogs_sbi_response_t *response);

--- a/lib/mb-smf-service-consumer/priv_mbs-session.h
+++ b/lib/mb-smf-service-consumer/priv_mbs-session.h
@@ -40,8 +40,15 @@ typedef struct _priv_mbs_session_s {
     ogs_hash_t              *active_subscriptions; /**< list of _priv_mbs_status_subscription_t indexed by their id */
     ogs_list_t               deleted_subscriptions;/**< list of _priv_mbs_status_subscription_t that are scheduled for deletion */
     mb_smf_sc_mbs_session_t *previous_session;     /**< Cached copy of the MBS Session as last accepted by the MB-SMF */
-    mb_smf_sc_mbs_session_create_result_cb create_result_cb;
+    mb_smf_sc_mbs_session_result_cb create_result_cb;
+    mb_smf_sc_mbs_session_result_cb update_result_cb;
+    mb_smf_sc_mbs_session_result_cb delete_result_cb;
     void                    *create_result_cb_data;
+    void                    *update_result_cb_data;
+    void                    *delete_result_cb_data;
+    mb_smf_sc_mbs_session_cb_data_free_fn create_cb_data_free;
+    mb_smf_sc_mbs_session_cb_data_free_fn update_cb_data_free;
+    mb_smf_sc_mbs_session_cb_data_free_fn delete_cb_data_free;
     bool                     deleted;
     _ref_count_sbi_object_t *sbi_object;
 } _priv_mbs_session_t;
@@ -80,18 +87,41 @@ ogs_list_t *_mbs_session_public_patch_list(const mb_smf_sc_mbs_session_t *a, con
 ogs_list_t *_mbs_session_patch_list(const _priv_mbs_session_t *session);
 
 bool _mbs_session_set_tmgi(_priv_mbs_session_t *session, _priv_tmgi_t *tmgi);
-bool _mbs_session_set_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_create_result_cb callback, void *data);
+bool _mbs_session_set_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+bool _mbs_session_set_create_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+bool _mbs_session_set_update_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+bool _mbs_session_set_delete_callback(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data);
+bool _mbs_session_set_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback, void *data,
+                                      mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn);
+bool _mbs_session_set_create_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback,
+                                             void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn);
+bool _mbs_session_set_update_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback,
+                                             void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn);
+bool _mbs_session_set_delete_callback_freefn(_priv_mbs_session_t *session, mb_smf_sc_mbs_session_result_cb callback,
+                                             void *data, mb_smf_sc_mbs_session_cb_data_free_fn data_free_fn);
 
 bool _mbs_session_push_changes(_priv_mbs_session_t *session);
 void _mbs_session_send_create(_priv_mbs_session_t *session);
 void _mbs_session_send_update(_priv_mbs_session_t *session);
 void _mbs_session_send_remove(_priv_mbs_session_t *session);
 
+void _mbs_session_release_callback_data(_priv_mbs_session_t *sess);
+void _mbs_session_release_create_callback_data(_priv_mbs_session_t *sess);
+void _mbs_session_release_update_callback_data(_priv_mbs_session_t *sess);
+void _mbs_session_release_delete_callback_data(_priv_mbs_session_t *sess);
+
 void _mbs_session_do_callback(_priv_mbs_session_t *session, int result, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_create_callback(_priv_mbs_session_t *session, int result, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_update_callback(_priv_mbs_session_t *session, int result, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_delete_callback(_priv_mbs_session_t *session, int result, const OpenAPI_problem_details_t *problem_details);
+
 void _mbs_session_do_created_callback(_priv_mbs_session_t *session);
 void _mbs_session_do_deleted_callback(_priv_mbs_session_t *session);
+void _mbs_session_do_updated_callback(_priv_mbs_session_t *session);
 void _mbs_session_do_create_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details);
 void _mbs_session_do_create_timeout_callback(_priv_mbs_session_t *session);
+void _mbs_session_do_update_error_callback(_priv_mbs_session_t *session, const OpenAPI_problem_details_t *problem_details);
+void _mbs_session_do_update_timeout_callback(_priv_mbs_session_t *session);
 
 void _mbs_session_subscriptions_update(_priv_mbs_session_t *sess);
 _priv_mbs_status_subscription_t *_mbs_session_find_active_subscription(const _priv_mbs_session_t *session, const char *id);

--- a/lib/mb-smf-service-consumer/priv_tmgi.h
+++ b/lib/mb-smf-service-consumer/priv_tmgi.h
@@ -98,7 +98,7 @@ char *_tmgi_list_repr(const ogs_list_t *tmgis);
 bool _tmgi_equal(const _priv_tmgi_t *a, const _priv_tmgi_t *b);
 const char *_tmgi_repr(const _priv_tmgi_t *tmgi);
 
-_priv_tmgi_t *_tmgi_copy(_priv_tmgi_t *old, const _priv_tmgi_t *src);
+_priv_tmgi_t *_tmgi_copy(_priv_tmgi_t **dest, const _priv_tmgi_t *src);
 
 OpenAPI_tmgi_t *_tmgi_to_openapi_type(const _priv_tmgi_t *tmgi);
 _priv_tmgi_t *_tmgi_find_matching_openapi_type(const OpenAPI_tmgi_t *api_tmgi);

--- a/lib/mb-smf-service-consumer/ref_count_sbi_object.h
+++ b/lib/mb-smf-service-consumer/ref_count_sbi_object.h
@@ -36,7 +36,10 @@ static inline void _ref_count_sbi_object_unref(_ref_count_sbi_object_t *ref_obj)
 {
     if (ref_obj) {
         ref_obj->ref_count--;
-        if (!ref_obj->ref_count) ogs_free(ref_obj);
+        if (!ref_obj->ref_count) {
+            ogs_sbi_xact_remove_all(&ref_obj->sbi_object);
+            ogs_free(ref_obj);
+        }
     }
 }
 

--- a/lib/mb-smf-service-consumer/tmgi.c
+++ b/lib/mb-smf-service-consumer/tmgi.c
@@ -104,11 +104,23 @@ void _tmgi_free(_priv_tmgi_t *tmgi)
 
     _context_remove_tmgi(tmgi);
 
-    if (tmgi->tmgi.mbs_service_id) ogs_free(tmgi->tmgi.mbs_service_id);
+    if (tmgi->tmgi.mbs_service_id) {
+        ogs_free(tmgi->tmgi.mbs_service_id);
+        tmgi->tmgi.mbs_service_id = NULL;
+    }
 
     if (tmgi->cache) {
-        if (tmgi->cache->repr) ogs_free(tmgi->cache->repr);
+        if (tmgi->cache->repr) {
+            ogs_free(tmgi->cache->repr);
+            tmgi->cache->repr = NULL;
+        }
         ogs_free(tmgi->cache);
+        tmgi->cache = NULL;
+    }
+
+    if (tmgi->sbi_object) {
+        _ref_count_sbi_object_unref(tmgi->sbi_object);
+        tmgi->sbi_object = NULL;
     }
 
     ogs_free(tmgi);
@@ -381,35 +393,38 @@ const char *_tmgi_repr(const _priv_tmgi_t *tmgi)
     return tmgi->cache->repr;
 }
 
-_priv_tmgi_t *_tmgi_copy(_priv_tmgi_t *old, const _priv_tmgi_t *src)
+_priv_tmgi_t *_tmgi_copy(_priv_tmgi_t **dest, const _priv_tmgi_t *src)
 {
     /* no change, just return */
-    if (old == src) return old;
+    if (*dest == src) return *dest;
 
     if (!src) {
-        _tmgi_free(old);
+        _tmgi_free(*dest);
+        *dest = NULL;
         return NULL;
     }
 
-    if (!old) old = _tmgi_create(src->callback, src->callback_data);
+    if (!*dest) *dest = _tmgi_create(src->callback, src->callback_data);
 
-    if (old->tmgi.mbs_service_id) {
-        ogs_free(old->tmgi.mbs_service_id);
-        old->tmgi.mbs_service_id = NULL;
+    _priv_tmgi_t *dst = *dest;
+
+    if (dst->tmgi.mbs_service_id) {
+        ogs_free(dst->tmgi.mbs_service_id);
+        dst->tmgi.mbs_service_id = NULL;
     }
     if (src->tmgi.mbs_service_id) {
-        old->tmgi.mbs_service_id = ogs_strdup(src->tmgi.mbs_service_id);
+        dst->tmgi.mbs_service_id = ogs_strdup(src->tmgi.mbs_service_id);
     }
 
-    memcpy(&old->tmgi.plmn, &src->tmgi.plmn, sizeof(src->tmgi.plmn));
+    memcpy(&dst->tmgi.plmn, &src->tmgi.plmn, sizeof(src->tmgi.plmn));
 
-    old->tmgi.expiry_time = src->tmgi.expiry_time;
+    dst->tmgi.expiry_time = src->tmgi.expiry_time;
 
-    _ref_count_sbi_object_unref(old->sbi_object);
-    old->sbi_object = _ref_count_sbi_object_ref(src->sbi_object);
-    _tmgi_clear_repr(old);
+    _ref_count_sbi_object_unref(dst->sbi_object);
+    dst->sbi_object = _ref_count_sbi_object_ref(src->sbi_object);
+    _tmgi_clear_repr(dst);
 
-    return old;
+    return dst;
 }
 
 _priv_tmgi_t *_tmgi_find_matching_openapi_type(const OpenAPI_tmgi_t *api_tmgi)

--- a/lib/mb-smf-service-consumer/utils.c
+++ b/lib/mb-smf-service-consumer/utils.c
@@ -105,7 +105,7 @@ char *_uint64_to_hex_str(uint64_t val, int min_digits, int max_digits)
 
 char *_bitrate_to_str(double bitrate)
 {
-    double divisor = 1.0; 
+    double divisor = 1.0;
     const char *units = "bps";
 
     if (bitrate >= 1e12) {

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 project('rt-5gc-service-consumers', 'c',
-    version : '2.1.1',
+    version : '2.1.2',
     license : '5G-MAG Public',
     meson_version : '>= 1.4.0',
     default_options : [


### PR DESCRIPTION
This fixes a few bugs and memory leaks and also adds some extra API calls to register separate create, update and delete callbacks along with functions to tidy up the optional data pointer that is registered with the callback.